### PR TITLE
Handle null or undefined children

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -73,7 +73,9 @@ const Animate = React.createClass({
       });
     }
     children.forEach((child) => {
-      this.performAppear(child.key);
+      if (child) {
+        this.performAppear(child.key);
+      }
     });
   },
 
@@ -97,7 +99,7 @@ const Animate = React.createClass({
     let newChildren = [];
     if (showProp) {
       currentChildren.forEach((currentChild) => {
-        const nextChild = findChildInChildrenByKey(nextChildren, currentChild.key);
+        const nextChild = currentChild && findChildInChildrenByKey(nextChildren, currentChild.key);
         let newChild;
         if ((!nextChild || !nextChild.props[showProp]) && currentChild.props[showProp]) {
           newChild = React.cloneElement(nextChild || currentChild, {
@@ -111,7 +113,7 @@ const Animate = React.createClass({
         }
       });
       nextChildren.forEach((nextChild) => {
-        if (!findChildInChildrenByKey(currentChildren, nextChild.key)) {
+        if (!nextChild || !findChildInChildrenByKey(currentChildren, nextChild.key)) {
           newChildren.push(nextChild);
         }
       });
@@ -128,11 +130,11 @@ const Animate = React.createClass({
     });
 
     nextChildren.forEach((child) => {
-      const key = child.key;
-      if (currentlyAnimatingKeys[key]) {
+      const key = child && child.key;
+      if (child && currentlyAnimatingKeys[key]) {
         return;
       }
-      const hasPrev = findChildInChildrenByKey(currentChildren, key);
+      const hasPrev = child && findChildInChildrenByKey(currentChildren, key);
       if (showProp) {
         const showInNext = child.props[showProp];
         if (hasPrev) {
@@ -149,11 +151,11 @@ const Animate = React.createClass({
     });
 
     currentChildren.forEach((child) => {
-      const key = child.key;
-      if (currentlyAnimatingKeys[key]) {
+      const key = child && child.key;
+      if (child && currentlyAnimatingKeys[key]) {
         return;
       }
-      const hasNext = findChildInChildrenByKey(nextChildren, key);
+      const hasNext = child && findChildInChildrenByKey(nextChildren, key);
       if (showProp) {
         const showInNow = child.props[showProp];
         if (hasNext) {
@@ -281,7 +283,7 @@ const Animate = React.createClass({
     let children = null;
     if (stateChildren) {
       children = stateChildren.map((child) => {
-        if (child === null) {
+        if (child === null || child === undefined) {
           return child;
         }
         if (!child.key) {

--- a/src/ChildrenUtils.js
+++ b/src/ChildrenUtils.js
@@ -15,7 +15,7 @@ export function findChildInChildrenByKey(children, key) {
       if (ret) {
         return;
       }
-      if (child.key === key) {
+      if (child && child.key === key) {
         ret = child;
       }
     });
@@ -27,7 +27,7 @@ export function findShownChildInChildrenByKey(children, key, showProp) {
   let ret = null;
   if (children) {
     children.forEach((child) => {
-      if (child.key === key && child.props[showProp]) {
+      if (child && child.key === key && child.props[showProp]) {
         if (ret) {
           throw new Error('two child with same key for <rc-animate> children');
         }
@@ -45,7 +45,7 @@ export function findHiddenChildInChildrenByKey(children, key, showProp) {
       if (found) {
         return;
       }
-      found = child.key === key && !child.props[showProp];
+      found = child && child.key === key && !child.props[showProp];
     });
   }
   return found;
@@ -56,10 +56,14 @@ export function isSameChildren(c1, c2, showProp) {
   if (same) {
     c1.forEach((child, index) => {
       const child2 = c2[index];
-      if (child.key !== child2.key) {
-        same = false;
-      } else if (showProp && child.props[showProp] !== child2.props[showProp]) {
-        same = false;
+      if (child && child2) {
+        if ((child && !child2) || (!child && child2)) {
+          same = false;
+        } else if (child.key !== child2.key) {
+          same = false;
+        } else if (showProp && child.props[showProp] !== child2.props[showProp]) {
+          same = false;
+        }
       }
     });
   }
@@ -74,7 +78,7 @@ export function mergeChildren(prev, next) {
   const nextChildrenPending = {};
   let pendingChildren = [];
   prev.forEach((child) => {
-    if (findChildInChildrenByKey(next, child.key)) {
+    if (child && findChildInChildrenByKey(next, child.key)) {
       if (pendingChildren.length) {
         nextChildrenPending[child.key] = pendingChildren;
         pendingChildren = [];
@@ -85,7 +89,7 @@ export function mergeChildren(prev, next) {
   });
 
   next.forEach((child) => {
-    if (nextChildrenPending.hasOwnProperty(child.key)) {
+    if (child && nextChildrenPending.hasOwnProperty(child.key)) {
       ret = ret.concat(nextChildrenPending[child.key]);
     }
     ret.push(child);

--- a/tests/multiple.spec.js
+++ b/tests/multiple.spec.js
@@ -143,6 +143,7 @@ describe('Animate', () => {
     ReactDOM.render(
       <Animate>
         {undefined}
+        {null}
         <div key="test"></div>
       </Animate>,
       container,

--- a/tests/multiple.spec.js
+++ b/tests/multiple.spec.js
@@ -138,4 +138,15 @@ describe('Animate', () => {
       done();
     }, 1400);
   });
+
+  it('does not fail with null/undefined children', function(done) {
+    ReactDOM.render(
+      <Animate>
+        {undefined}
+        <div key='test'></div>
+      </Animate>,
+      container,
+      done
+    );
+  });
 });

--- a/tests/multiple.spec.js
+++ b/tests/multiple.spec.js
@@ -139,11 +139,11 @@ describe('Animate', () => {
     }, 1400);
   });
 
-  it('does not fail with null/undefined children', function(done) {
+  it('does not fail with null/undefined children', (done) => {
     ReactDOM.render(
       <Animate>
         {undefined}
-        <div key='test'></div>
+        <div key="test"></div>
       </Animate>,
       container,
       done


### PR DESCRIPTION
Handles cases where `<Animate />` is declared like so:

```jsx
<Animate>
  {undefined}
  <div key='example'></div>
</Animate>
```

I've verified this with a test and in my own case, but please let me know if there's any additional testing needed to make sure this doesn't cause problems?

Fixes #7.