### PR TITLE
Add support for Object type for `transitionName` prop of `Animate` …

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -29,7 +29,10 @@ const Animate = React.createClass({
   propTypes: {
     component: React.PropTypes.any,
     animation: React.PropTypes.object,
-    transitionName: React.PropTypes.string,
+    transitionName: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.object,
+    ]),
     transitionEnter: React.PropTypes.bool,
     transitionAppear: React.PropTypes.bool,
     exclusive: React.PropTypes.bool,

--- a/src/AnimateChild.js
+++ b/src/AnimateChild.js
@@ -49,6 +49,7 @@ const AnimateChild = React.createClass({
     const node = ReactDOM.findDOMNode(this);
     const props = this.props;
     const transitionName = props.transitionName;
+    const nameIsObj = typeof transitionName === 'object';
     this.stop();
     const end = () => {
       this.stopper = null;
@@ -56,7 +57,8 @@ const AnimateChild = React.createClass({
     };
     if ((isCssAnimationSupported || !props.animation[animationType]) &&
       transitionName && props[transitionMap[animationType]]) {
-      this.stopper = cssAnimate(node, `${transitionName}-${animationType}`, end);
+      const name = nameIsObj ? transitionName[animationType] : `${transitionName}-${animationType}`;
+      this.stopper = cssAnimate(node, name, end);
     } else {
       this.stopper = props.animation[animationType](node, end);
     }


### PR DESCRIPTION
…component

(Similar to `transitionName` prop of `ReactCSSTransitionGroup` component.
https://facebook.github.io/react/docs/animation.html#custom-classes )

Fix https://github.com/react-component/animate/issues/8