### PR TITLE
Fix deprecation warnings for react >= 15.5.0

### DIFF
--- a/examples/alert.js
+++ b/examples/alert.js
@@ -2,16 +2,17 @@
 
 import './assets/index.less';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Animate from 'rc-animate';
 let seed = 0;
 
 const Alert = React.createClass({
   propTypes: {
-    time: React.PropTypes.number,
-    type: React.PropTypes.string,
-    str: React.PropTypes.string,
-    onEnd: React.PropTypes.func,
+    time: PropTypes.number,
+    type: PropTypes.string,
+    str: PropTypes.string,
+    onEnd: PropTypes.func,
   },
 
   getDefaultProps() {

--- a/examples/hide-todo.js
+++ b/examples/hide-todo.js
@@ -1,7 +1,8 @@
 /* eslint no-console:0, react/no-multi-comp:0 */
 
 import './assets/index.less';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Animate from 'rc-animate';
 import assign from 'object-assign';

--- a/examples/simple-animation.js
+++ b/examples/simple-animation.js
@@ -2,7 +2,8 @@
 
 import './assets/index.less';
 import Animate from 'rc-animate';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import velocity from 'velocity-animate';
 const Box = React.createClass({

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -2,7 +2,8 @@
 
 import './assets/slow.less';
 import Animate from 'rc-animate';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import assign from 'object-assign';
 

--- a/examples/todo-animation.js
+++ b/examples/todo-animation.js
@@ -1,7 +1,8 @@
 /* eslint no-console:0, react/no-multi-comp:0, no-alert:0 */
 
 import './assets/index.less';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Animate from 'rc-animate';
 import velocity from 'velocity-animate';

--- a/examples/todo.js
+++ b/examples/todo.js
@@ -1,7 +1,8 @@
 /* eslint no-console:0, react/no-multi-comp:0, no-alert:0 */
 
 import './assets/index.less';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Animate from 'rc-animate';
 

--- a/examples/transitionAppear.js
+++ b/examples/transitionAppear.js
@@ -2,7 +2,8 @@
 
 import './assets/slow.less';
 import Animate from 'rc-animate';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 const Box = React.createClass({

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lint"
   ],
   "dependencies": {
+    "create-react-class": "^15.5.1",
     "css-animation": "^1.3.0",
     "prop-types": "^15.5.6"
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lint"
   ],
   "dependencies": {
-    "css-animation": "^1.3.0"
+    "css-animation": "^1.3.0",
+    "prop-types": "^15.5.6"
   }
 }

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -26,7 +26,8 @@ function getChildrenFromProps(props) {
 function noop() {
 }
 
-const Animate = React.createClass({
+const createReactClass = require('create-react-class');
+const Animate = createReactClass({
   propTypes: {
     component: PropTypes.any,
     componentProps: PropTypes.object,

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   toArrayChildren,
   mergeChildren,
@@ -27,22 +28,22 @@ function noop() {
 
 const Animate = React.createClass({
   propTypes: {
-    component: React.PropTypes.any,
-    componentProps: React.PropTypes.object,
-    animation: React.PropTypes.object,
-    transitionName: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object,
+    component: PropTypes.any,
+    componentProps: PropTypes.object,
+    animation: PropTypes.object,
+    transitionName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.object,
     ]),
-    transitionEnter: React.PropTypes.bool,
-    transitionAppear: React.PropTypes.bool,
-    exclusive: React.PropTypes.bool,
-    transitionLeave: React.PropTypes.bool,
-    onEnd: React.PropTypes.func,
-    onEnter: React.PropTypes.func,
-    onLeave: React.PropTypes.func,
-    onAppear: React.PropTypes.func,
-    showProp: React.PropTypes.string,
+    transitionEnter: PropTypes.bool,
+    transitionAppear: PropTypes.bool,
+    exclusive: PropTypes.bool,
+    transitionLeave: PropTypes.bool,
+    onEnd: PropTypes.func,
+    onEnter: PropTypes.func,
+    onLeave: PropTypes.func,
+    onAppear: PropTypes.func,
+    showProp: PropTypes.string,
   },
 
   getDefaultProps() {

--- a/src/AnimateChild.js
+++ b/src/AnimateChild.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import cssAnimate, { isCssAnimationSupported } from 'css-animation';
 import animUtil from './util';
@@ -11,7 +12,7 @@ const transitionMap = {
 
 const AnimateChild = React.createClass({
   propTypes: {
-    children: React.PropTypes.any,
+    children: PropTypes.any,
   },
 
   componentWillUnmount() {

--- a/src/AnimateChild.js
+++ b/src/AnimateChild.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import cssAnimate, { isCssAnimationSupported } from 'css-animation';
@@ -10,7 +9,8 @@ const transitionMap = {
   leave: 'transitionLeave',
 };
 
-const AnimateChild = React.createClass({
+const createReactClass = require('create-react-class');
+const AnimateChild = createReactClass({
   propTypes: {
     children: PropTypes.any,
   },

--- a/tests/multiple.spec.js
+++ b/tests/multiple.spec.js
@@ -2,7 +2,7 @@
 const Animate = require('../');
 const React = require('react');
 const ReactDOM = require('react-dom');
-const PropTypes = React.PropTypes;
+const PropTypes = require('prop-types');
 const TestUtils = require('react-addons-test-utils');
 const expect = require('expect.js');
 require('./index.spec.css');

--- a/tests/multiple.spec.js
+++ b/tests/multiple.spec.js
@@ -5,9 +5,10 @@ const ReactDOM = require('react-dom');
 const PropTypes = require('prop-types');
 const TestUtils = require('react-addons-test-utils');
 const expect = require('expect.js');
+const createReactClass = require('create-react-class');
 require('./index.spec.css');
 
-const Todo = React.createClass({
+const Todo = createReactClass({
   propTypes: {
     end: PropTypes.func,
     onClick: PropTypes.func,
@@ -30,7 +31,7 @@ const Todo = React.createClass({
     </div>);
   },
 });
-const TodoList = React.createClass({
+const TodoList = createReactClass({
   getInitialState() {
     return { items: ['hello', 'world', 'click', 'me'] };
   },

--- a/tests/single-animation.spec.js
+++ b/tests/single-animation.spec.js
@@ -2,11 +2,12 @@
 
 const Animate = require('../index');
 const React = require('react');
+const createReactClass = require('create-react-class');
 require('./index.spec.css');
 const $ = require('jquery');
 
 function createClass(options) {
-  return React.createClass({
+  return createReactClass({
     getInitialState() {
       return {
         transitionEnter: options.transitionEnter,

--- a/tests/single.spec.js
+++ b/tests/single.spec.js
@@ -2,11 +2,12 @@
 
 const Animate = require('../index');
 const React = require('react');
+const createReactClass = require('create-react-class');
 
 require('./index.spec.css');
 
 function createClass(options) {
-  return React.createClass({
+  return createReactClass({
     getInitialState() {
       return {
         transitionEnter: options.transitionEnter,


### PR DESCRIPTION
Hi.

In React v15.5.0, `React.PropTypes` and `React.createClass` became deprecate.
So I migrated to `prop-types` package and `create-react-class`  package.

Ref: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html