### PR TITLE
fix a bug of onLeave will not called

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -263,10 +263,9 @@ export default class Animate extends React.Component {
           currentChildren, props.showProp)) {
         this.setState({
           children: currentChildren,
-        }, end);
-      } else {
-        end();
+        });
       }
+      end();
     }
   }
 

--- a/tests/end.spec.js
+++ b/tests/end.spec.js
@@ -2,7 +2,6 @@
 const Animate = require('../');
 const React = require('react');
 const ReactDOM = require('react-dom');
-const TestUtils = require('react-addons-test-utils');
 const expect = require('expect.js');
 require('./index.spec.css');
 
@@ -10,7 +9,7 @@ class Child extends React.Component {
   state = {
     visible: true,
   };
-  onClick = () => {
+  componentDidMount() {
     // strange setTimeout
     setTimeout(() => {
       this.setState({ visible: false });
@@ -19,14 +18,9 @@ class Child extends React.Component {
   }
   render() {
     return (
-      <div>
-        <Animate onLeave={this.props.onLeave} transitionName="example">
-          {this.state.visible ? <div key="xxxx">xxxx</div> : null}
-        </Animate>
-        <button id="remove" onClick={this.onClick}>
-          click here to remove father
-        </button>
-      </div>
+      <Animate onLeave={this.props.onLeave} transitionName="example">
+        {this.state.visible ? <div key="xxxx">xxxx</div> : null}
+      </Animate>
     );
   }
 }
@@ -68,10 +62,9 @@ describe('animation end', () => {
   });
 
   it('onLeave should always be triggered when father is unmounted', (done) => {
-    TestUtils.Simulate.click(document.getElementById('remove'));
     setTimeout(() => {
       expect(onLeaveCalled).to.be(true);
       done();
-    }, 500);
+    }, 0);
   });
 });

--- a/tests/end.spec.js
+++ b/tests/end.spec.js
@@ -1,0 +1,77 @@
+/* eslint no-console:0, react/no-multi-comp:0, react/prop-types:0 */
+const Animate = require('../');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const TestUtils = require('react-addons-test-utils');
+const expect = require('expect.js');
+require('./index.spec.css');
+
+class Child extends React.Component {
+  state = {
+    visible: true,
+  };
+  onClick = () => {
+    // strange setTimeout
+    setTimeout(() => {
+      this.setState({ visible: false });
+      this.props.onClick();
+    }, 0);
+  }
+  render() {
+    return (
+      <div>
+        <Animate onLeave={this.props.onLeave} transitionName="example">
+          {this.state.visible ? <div key="xxxx">xxxx</div> : null}
+        </Animate>
+        <button id="remove" onClick={this.onClick}>
+          click here to remove father
+        </button>
+      </div>
+    );
+  }
+}
+
+class App extends React.Component {
+  state = {
+    visible: true,
+  }
+  removeFather = () => {
+    this.setState({ visible: false });
+  }
+  render() {
+    return this.state.visible
+      ? <Child onClick={this.removeFather} onLeave={this.props.onLeave} /> : null;
+  }
+}
+
+describe('animation end', () => {
+  let onLeaveCalled;
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const onLeave = () => {
+    onLeaveCalled = true;
+  };
+
+  beforeEach((done) => {
+    ReactDOM.render(<App onLeave={onLeave} />, container, () => {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    try {
+      ReactDOM.unmountComponentAtNode(container);
+    } catch (e) {
+      console.log(e);
+      container.innerHTML = '';
+    }
+  });
+
+  it('onLeave should always be triggered when father is unmounted', (done) => {
+    TestUtils.Simulate.click(document.getElementById('remove'));
+    setTimeout(() => {
+      expect(onLeaveCalled).to.be(true);
+      done();
+    }, 500);
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,4 @@
 require('./single.spec');
 require('./single-animation.spec');
 require('./multiple.spec');
+require('./end.spec');


### PR DESCRIPTION
这里的改动触发了这个问题：https://github.com/react-component/animate/commit/155d824dc2f87b5c28315bdfeb98cf4921125ebc#diff-9bab3275b4ae83217ddb6dfa6ee5fc16L255

触发的方式非常刁钻，逻辑大概是：

1. 子元素在 setTimeout 里触发了 animate 的离场流程，同时触发了父元素的销毁过程。
2. 离场流程走到一半，由于父元素销毁流程是异步的，导致 setState 之后的回调没有被触发，从而没有调用 onLeave：`进入离场流程但是没有调用 onLeave`。

解决方式是把 onLeave 的逻辑回滚为直接触发，但是不知道上面原始的改动是解决什么问题的。@yiminghe 来决定是否合并吧。

> 仍然不知道 setTimeout 起了什么作用，按道理只是延时了整体事件发生的时机，并没有改变事件的顺序。