### PR TITLE
add `children` to propTypes

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -44,6 +44,7 @@ export default class Animate extends React.Component {
     onLeave: PropTypes.func,
     onAppear: PropTypes.func,
     showProp: PropTypes.string,
+    children: PropTypes.node,
   }
 
   static defaultProps = {


### PR DESCRIPTION
Since &lt;Animate&gt;&lt;/Animate&gt; contains children, the `children` props should be specified.

Complete this props give automatic scripts the ability to detect whether the component is self-closing or not.