### PR TITLE
feat: Support `keys` as an object

### DIFF
--- a/examples/CSSMotionList.js
+++ b/examples/CSSMotionList.js
@@ -48,6 +48,7 @@ class Demo extends React.Component {
 
     return (
       <div>
+        key 3 is a different component with others.
         {/* Input field */}
         <div>
           <label>

--- a/examples/CSSMotionList.js
+++ b/examples/CSSMotionList.js
@@ -23,12 +23,20 @@ class Demo extends React.Component {
 
   onFlushMotion = () => {
     const { count, checkedMap } = this.state;
-    const keyList = [];
+    let keyList = [];
     for (let i = 0; i < count; i += 1) {
       if (checkedMap[i] !== false) {
         keyList.push(i);
       }
     }
+
+    keyList = keyList.map(key => {
+      if (key === 3) {
+        return { key, background: 'orange' };
+      }
+      return key;
+    });
+
     this.setState({ keyList });
   };
 
@@ -82,11 +90,14 @@ class Demo extends React.Component {
           onEnterEnd={this.skipColorTransition}
           onLeaveEnd={this.skipColorTransition}
         >
-          {({ key, className, style }) => {
+          {({ key, background, className, style }) => {
             return (
               <div
                 className={classNames('demo-block', className)}
-                style={style}
+                style={{
+                  ...style,
+                  background,
+                }}
               >
                 <span>{key}</span>
               </div>

--- a/src/CSSMotion.js
+++ b/src/CSSMotion.js
@@ -26,7 +26,7 @@ export function genCSSMotion(transitionSupport) {
 
   class CSSMotion extends React.Component {
     static propTypes = {
-      eventKey: PropTypes.any, // Internal usage. Only pass by CSSMotionList
+      eventProps: PropTypes.object, // Internal usage. Only pass by CSSMotionList
       visible: PropTypes.bool,
       children: PropTypes.func,
       motionName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
@@ -225,22 +225,22 @@ export function genCSSMotion(transitionSupport) {
 
     render() {
       const { status, statusActive, statusStyle } = this.state;
-      const { children, motionName, visible, removeOnLeave, leavedClassName, eventKey } = this.props;
+      const { children, motionName, visible, removeOnLeave, leavedClassName, eventProps } = this.props;
 
       if (!children) return null;
 
       if (status === STATUS_NONE || !isSupportTransition(this.props)) {
         if (visible) {
-          return children({ key: eventKey });
+          return children({ ...eventProps });
         } else if (!removeOnLeave) {
-          return children({ key: eventKey, className: leavedClassName });
+          return children({ ...eventProps, className: leavedClassName });
         }
 
         return null;
       }
 
       return children({
-        key: eventKey,
+        ...eventProps,
         className: classNames({
           [getTransitionName(motionName, status)]: status !== STATUS_NONE,
           [getTransitionName(motionName, `${status}-active`)]: status !== STATUS_NONE && statusActive,

--- a/src/CSSMotionList.jsx
+++ b/src/CSSMotionList.jsx
@@ -3,7 +3,7 @@ import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
 import CSSMotion from './CSSMotion';
 import { supportTransition } from './util/motion';
-import { diffKeys } from './util/diff';
+import { STATUS_ADD, STATUS_KEEP, diffKeys, parseKeys } from './util/diff';
 
 const MOTION_PROP_NAMES = Object.keys(CSSMotion.propTypes);
 
@@ -24,10 +24,12 @@ export function genCSSMotionList(transitionSupport) {
     };
 
     static getDerivedStateFromProps({ keys }, { keyEntities }) {
+      const parsedKeyObjects = parseKeys(keys);
+
       // Always as keep when motion not support
       if (!transitionSupport) {
         return {
-          keyEntities: keys.map((key) => ({ key, keep: true })),
+          keyEntities: parsedKeyObjects.map((obj) => ({ ...obj, status: STATUS_KEEP })),
         };
       }
 
@@ -80,8 +82,8 @@ export function genCSSMotionList(transitionSupport) {
 
       return (
         <Component {...restProps}>
-          {keyEntities.map(({ key, add, keep }) => {
-            const visible = !!(add || keep);
+          {keyEntities.map(({ key, status }) => {
+            const visible = status === STATUS_ADD || status === STATUS_KEEP;
             return (
               <CSSMotion
                 {...motionProps}

--- a/src/util/diff.js
+++ b/src/util/diff.js
@@ -1,3 +1,18 @@
+export const STATUS_ADD = 'add';
+export const STATUS_KEEP = 'keep';
+export const STATUS_REMOVE = 'remove';
+
+export function wrapKeyToObject(key) {
+  if (key && typeof key === 'object' && 'key' in key) {
+    return key;
+  }
+  return { key };
+}
+
+export function parseKeys(keys = []) {
+  return keys.map(wrapKeyToObject);
+}
+
 export function diffKeys(prevKeys = [], currentKeys = []) {
   let list = [];
   let currentIndex = 0;
@@ -13,13 +28,13 @@ export function diffKeys(prevKeys = [], currentKeys = []) {
         // New added keys should add before current key
         if (currentIndex < i) {
           list = list.concat(
-            currentKeys.slice(currentIndex, i).map(addKey => ({ key: addKey, add: true }))
+            currentKeys.slice(currentIndex, i).map(addKey => ({ key: addKey, status: STATUS_ADD }))
           );
           currentIndex = i;
         }
         list.push({
           key,
-          keep: true,
+          status: STATUS_KEEP,
         });
         currentIndex += 1;
 
@@ -32,7 +47,7 @@ export function diffKeys(prevKeys = [], currentKeys = []) {
     if (!hit) {
       list.push({
         key,
-        remove: true,
+        status: STATUS_REMOVE,
       });
     }
   });
@@ -40,11 +55,9 @@ export function diffKeys(prevKeys = [], currentKeys = []) {
   // Add rest to the list
   if (currentIndex < currentLen) {
     list = list.concat(
-      currentKeys.slice(currentIndex).map(addKey => ({ key: addKey, add: true }))
+      currentKeys.slice(currentIndex).map(addKey => ({ key: addKey, status: STATUS_ADD }))
     );
   }
 
   return list;
 }
-
-export default diffKeys;

--- a/src/util/diff.js
+++ b/src/util/diff.js
@@ -1,6 +1,7 @@
 export const STATUS_ADD = 'add';
 export const STATUS_KEEP = 'keep';
 export const STATUS_REMOVE = 'remove';
+export const STATUS_REMOVED = 'removed';
 
 export function wrapKeyToObject(key) {
   if (key && typeof key === 'object' && 'key' in key) {
@@ -18,22 +19,25 @@ export function diffKeys(prevKeys = [], currentKeys = []) {
   let currentIndex = 0;
   const currentLen = currentKeys.length;
 
+  const prevKeyObjects = parseKeys(prevKeys);
+  const currentKeyObjects = parseKeys(currentKeys);
+
   // Check prev keys to insert or keep
-  prevKeys.forEach((key) => {
+  prevKeyObjects.forEach((keyObj) => {
     let hit = false;
 
     for (let i = currentIndex; i < currentLen; i += 1) {
-      const currentKey = currentKeys[i];
-      if (currentKey === key) {
+      const currentKeyObj = currentKeyObjects[i];
+      if (currentKeyObj.key === keyObj.key) {
         // New added keys should add before current key
         if (currentIndex < i) {
           list = list.concat(
-            currentKeys.slice(currentIndex, i).map(addKey => ({ key: addKey, status: STATUS_ADD }))
+            currentKeyObjects.slice(currentIndex, i).map(obj => ({ ...obj, status: STATUS_ADD }))
           );
           currentIndex = i;
         }
         list.push({
-          key,
+          ...currentKeyObj,
           status: STATUS_KEEP,
         });
         currentIndex += 1;
@@ -46,7 +50,7 @@ export function diffKeys(prevKeys = [], currentKeys = []) {
     // If not hit, it means key is removed
     if (!hit) {
       list.push({
-        key,
+        ...keyObj,
         status: STATUS_REMOVE,
       });
     }
@@ -55,7 +59,7 @@ export function diffKeys(prevKeys = [], currentKeys = []) {
   // Add rest to the list
   if (currentIndex < currentLen) {
     list = list.concat(
-      currentKeys.slice(currentIndex).map(addKey => ({ key: addKey, status: STATUS_ADD }))
+      currentKeyObjects.slice(currentIndex).map(obj => ({ ...obj, status: STATUS_ADD }))
     );
   }
 

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -1,6 +1,6 @@
 /* eslint react/no-render-return-value:0, react/prefer-stateless-function:0, react/no-multi-comp:0 */
 import expect from 'expect.js';
-import { diffKeys } from '../src/util/diff';
+import { STATUS_ADD, STATUS_KEEP, STATUS_REMOVE, diffKeys } from '../src/util/diff';
 
 import './CSSMotion.spec.css';
 
@@ -13,12 +13,12 @@ describe('util', () => {
       expect(
         diffKeys(prevKeys, currentKeys)
       ).to.eql([
-        { key: 1, keep: true },
-        { key: 2, add: true },
-        { key: 3, keep: true },
-        { key: 4, add: true },
-        { key: 5, add: true },
-        { key: 6, keep: true },
+        { key: 1, status: STATUS_KEEP },
+        { key: 2, status: STATUS_ADD },
+        { key: 3, status: STATUS_KEEP },
+        { key: 4, status: STATUS_ADD },
+        { key: 5, status: STATUS_ADD },
+        { key: 6, status: STATUS_KEEP },
       ]);
     });
 
@@ -29,12 +29,12 @@ describe('util', () => {
       expect(
         diffKeys(prevKeys, currentKeys)
       ).to.eql([
-        { key: 1, add: true },
-        { key: 2, add: true },
-        { key: 3, keep: true },
-        { key: 4, add: true },
-        { key: 5, add: true },
-        { key: 6, add: true },
+        { key: 1, status: STATUS_ADD },
+        { key: 2, status: STATUS_ADD },
+        { key: 3, status: STATUS_KEEP },
+        { key: 4, status: STATUS_ADD },
+        { key: 5, status: STATUS_ADD },
+        { key: 6, status: STATUS_ADD },
       ]);
     });
 
@@ -45,12 +45,12 @@ describe('util', () => {
       expect(
         diffKeys(prevKeys, currentKeys)
       ).to.eql([
-        { key: 1, remove: true },
-        { key: 2, keep: true },
-        { key: 3, remove: true },
-        { key: 4, keep: true },
-        { key: 5, keep: true },
-        { key: 6, remove: true },
+        { key: 1, status: STATUS_REMOVE },
+        { key: 2, status: STATUS_KEEP },
+        { key: 3, status: STATUS_REMOVE },
+        { key: 4, status: STATUS_KEEP },
+        { key: 5, status: STATUS_KEEP },
+        { key: 6, status: STATUS_REMOVE },
       ]);
     });
 
@@ -62,15 +62,15 @@ describe('util', () => {
       expect(
         diffKeys(prevKeys, currentKeys)
       ).to.eql([
-        { key: 1, remove: true },
-        { key: 2, add: true },
-        { key: 3, keep: true },
-        { key: 5, remove: true },
-        { key: 7, remove: true },
-        { key: 4, add: true },
-        { key: 6, add: true },
-        { key: 8, keep: true },
-        { key: 9, remove: true },
+        { key: 1, status: STATUS_REMOVE },
+        { key: 2, status: STATUS_ADD },
+        { key: 3, status: STATUS_KEEP },
+        { key: 5, status: STATUS_REMOVE },
+        { key: 7, status: STATUS_REMOVE },
+        { key: 4, status: STATUS_ADD },
+        { key: 6, status: STATUS_ADD },
+        { key: 8, status: STATUS_KEEP },
+        { key: 9, status: STATUS_REMOVE },
       ]);
     });
   });

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -73,5 +73,17 @@ describe('util', () => {
         { key: 9, status: STATUS_REMOVE },
       ]);
     });
+
+    it('should diff keep the key content', () => {
+      const prevKeys = [1, { key: 2, test: true }];
+      const currentKeys = [{ key: 1, test: true }];
+
+      expect(
+        diffKeys(prevKeys, currentKeys)
+      ).to.eql([
+        { key: 1, status: STATUS_KEEP, test: true },
+        { key: 2, status: STATUS_REMOVE, test: true },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Since in `rc-tree-select`, it put different component into one Animate. CSSMotionList should also support renderProps with different components.