### PR TITLE
feat: Support `ref` to render props

### DIFF
--- a/examples/CSSMotion.js
+++ b/examples/CSSMotion.js
@@ -7,7 +7,10 @@ import { CSSMotion } from 'rc-animate';
 import classNames from 'classnames';
 import './CSSMotion.less';
 
+window.motionRef = React.createRef();
+
 class Demo extends React.Component {
+
   state = {
     show: true,
     motionLeaveImmediately: false,
@@ -93,9 +96,11 @@ class Demo extends React.Component {
 
               onEnterEnd={this.skipColorTransition}
               onLeaveEnd={this.skipColorTransition}
+
+              ref={window.motionRef}
             >
-              {({ style, className }) => (
-                <div className={classNames('demo-block', className)} style={style} />
+              {({ style, className }, ref) => (
+                <div ref={ref} className={classNames('demo-block', className)} style={style} />
               )}
             </CSSMotion>
           </div>

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "css-animation": "^1.3.2",
     "prop-types": "15.x",
     "raf": "^3.4.0",
+    "rc-util": "^4.8.0",
     "react-lifecycles-compat": "^3.0.4"
   }
 }

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -31,6 +31,8 @@ export default class Animate extends React.Component {
   static isAnimate = true; // eslint-disable-line
   
   static propTypes = {
+    className: PropTypes.string,
+    style: PropTypes.object,
     component: PropTypes.any,
     componentProps: PropTypes.object,
     animation: PropTypes.object,

--- a/src/AnimateChild.js
+++ b/src/AnimateChild.js
@@ -13,6 +13,8 @@ const transitionMap = {
 export default class AnimateChild extends React.Component {
   static propTypes = {
     children: PropTypes.any,
+    animation: PropTypes.any,
+    transitionName: PropTypes.any,
   }
 
   componentWillUnmount() {

--- a/src/CSSMotion.js
+++ b/src/CSSMotion.js
@@ -1,7 +1,8 @@
+/* eslint-disable react/default-props-match-prop-types, react/no-multi-comp */
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { polyfill } from 'react-lifecycles-compat';
+import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
 import classNames from 'classnames';
 import raf from 'raf';
 import {
@@ -15,6 +16,28 @@ const STATUS_APPEAR = 'appear';
 const STATUS_ENTER = 'enter';
 const STATUS_LEAVE = 'leave';
 
+export const MotionPropTypes = {
+  eventProps: PropTypes.object, // Internal usage. Only pass by CSSMotionList
+  visible: PropTypes.bool,
+  children: PropTypes.func,
+  motionName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+  motionAppear: PropTypes.bool,
+  motionEnter: PropTypes.bool,
+  motionLeave: PropTypes.bool,
+  motionLeaveImmediately: PropTypes.bool, // Trigger leave motion immediately
+  removeOnLeave: PropTypes.bool,
+  leavedClassName: PropTypes.string,
+  onAppearStart: PropTypes.func,
+  onAppearActive: PropTypes.func,
+  onAppearEnd: PropTypes.func,
+  onEnterStart: PropTypes.func,
+  onEnterActive: PropTypes.func,
+  onEnterEnd: PropTypes.func,
+  onLeaveStart: PropTypes.func,
+  onLeaveActive: PropTypes.func,
+  onLeaveEnd: PropTypes.func,
+};
+
 /**
  * `transitionSupport` is used for none transition test case.
  * Default we use browser transition event support check.
@@ -26,25 +49,11 @@ export function genCSSMotion(transitionSupport) {
 
   class CSSMotion extends React.Component {
     static propTypes = {
-      eventProps: PropTypes.object, // Internal usage. Only pass by CSSMotionList
-      visible: PropTypes.bool,
-      children: PropTypes.func,
-      motionName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-      motionAppear: PropTypes.bool,
-      motionEnter: PropTypes.bool,
-      motionLeave: PropTypes.bool,
-      motionLeaveImmediately: PropTypes.bool, // Trigger leave motion immediately
-      removeOnLeave: PropTypes.bool,
-      leavedClassName: PropTypes.string,
-      onAppearStart: PropTypes.func,
-      onAppearActive: PropTypes.func,
-      onAppearEnd: PropTypes.func,
-      onEnterStart: PropTypes.func,
-      onEnterActive: PropTypes.func,
-      onEnterEnd: PropTypes.func,
-      onLeaveStart: PropTypes.func,
-      onLeaveActive: PropTypes.func,
-      onLeaveEnd: PropTypes.func,
+      ...MotionPropTypes,
+      
+      internalRef: PropTypes.oneOfType([
+        PropTypes.object, PropTypes.func
+      ]),
     };
 
     static defaultProps = {
@@ -64,7 +73,8 @@ export function genCSSMotion(transitionSupport) {
         newStatus: false,
         statusStyle: null,
       };
-      this.$ele = null;
+      this.$cacheEle = null;
+      this.node = null;
       this.raf = null;
     }
 
@@ -116,7 +126,7 @@ export function genCSSMotion(transitionSupport) {
 
     componentWillUnmount() {
       this._destroyed = true;
-      this.removeEventListener(this.$ele);
+      this.removeEventListener(this.$cacheEle);
       this.cancelNextFrame();
     }
 
@@ -133,11 +143,11 @@ export function genCSSMotion(transitionSupport) {
       }
 
       // Event injection
-      const $ele = ReactDOM.findDOMNode(this);
-      if (this.$ele !== $ele) {
-        this.removeEventListener(this.$ele);
+      const $ele = this.getElement();
+      if (this.$cacheEle !== $ele) {
+        this.removeEventListener(this.$cacheEle);
         this.addEventListener($ele);
-        this.$ele = $ele;
+        this.$cacheEle = $ele;
       }
 
       // Init status
@@ -168,6 +178,21 @@ export function genCSSMotion(transitionSupport) {
       }
     };
 
+    setNodeRef = (node) => {
+      const { internalRef } = this.props;
+      this.node = node;
+
+      if (typeof internalRef === 'function') {
+        internalRef(node);
+      } else if ('current' in internalRef) {
+        internalRef.current = node;
+      }
+    };
+
+    getElement = () => {
+      return findDOMNode(this.node || this);
+    };
+
     addEventListener = ($ele) => {
       if (!$ele) return;
 
@@ -182,7 +207,7 @@ export function genCSSMotion(transitionSupport) {
     };
 
     updateStatus = (styleFunc, additionalState, event, callback) => {
-      const statusStyle = styleFunc ? styleFunc(ReactDOM.findDOMNode(this), event) : null;
+      const statusStyle = styleFunc ? styleFunc(this.getElement(), event) : null;
 
       if (statusStyle === false || this._destroyed) return;
 
@@ -231,9 +256,9 @@ export function genCSSMotion(transitionSupport) {
 
       if (status === STATUS_NONE || !isSupportTransition(this.props)) {
         if (visible) {
-          return children({ ...eventProps });
+          return children({ ...eventProps }, this.setNodeRef);
         } else if (!removeOnLeave) {
-          return children({ ...eventProps, className: leavedClassName });
+          return children({ ...eventProps, className: leavedClassName }, this.setNodeRef);
         }
 
         return null;
@@ -247,13 +272,17 @@ export function genCSSMotion(transitionSupport) {
           [motionName]: typeof motionName === 'string',
         }),
         style: statusStyle,
-      });
+      }, this.setNodeRef);
     }
   }
 
   polyfill(CSSMotion);
 
-  return CSSMotion;
+  if (!React.forwardRef) {
+    return CSSMotion;
+  }
+
+  return React.forwardRef((props, ref) => <CSSMotion internalRef={ref} {...props} />);
 }
 
 export default genCSSMotion(supportTransition);

--- a/src/CSSMotion.js
+++ b/src/CSSMotion.js
@@ -42,7 +42,15 @@ export const MotionPropTypes = {
  * `transitionSupport` is used for none transition test case.
  * Default we use browser transition event support check.
  */
-export function genCSSMotion(transitionSupport) {
+export function genCSSMotion(config) {
+  let transitionSupport;
+  let forwardRef = !!React.forwardRef;
+
+  if (typeof config === 'object') {
+    transitionSupport = config.transitionSupport;
+    forwardRef = 'forwardRef' in config ? config.forwardRef : forwardRef;
+  }
+
   function isSupportTransition(props) {
     return !!(props.motionName && transitionSupport);
   }
@@ -278,7 +286,7 @@ export function genCSSMotion(transitionSupport) {
 
   polyfill(CSSMotion);
 
-  if (!React.forwardRef) {
+  if (!forwardRef) {
     return CSSMotion;
   }
 

--- a/src/CSSMotion.js
+++ b/src/CSSMotion.js
@@ -192,7 +192,7 @@ export function genCSSMotion(config) {
 
       if (typeof internalRef === 'function') {
         internalRef(node);
-      } else if ('current' in internalRef) {
+      } else if (internalRef && 'current' in internalRef) {
         internalRef.current = node;
       }
     };

--- a/src/CSSMotionList.jsx
+++ b/src/CSSMotionList.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { polyfill } from 'react-lifecycles-compat';
 import PropTypes from 'prop-types';
-import OriginCSSMotion from './CSSMotion';
+import OriginCSSMotion, { MotionPropTypes } from './CSSMotion';
 import { supportTransition } from './util/motion';
 import { STATUS_ADD, STATUS_KEEP, STATUS_REMOVE, STATUS_REMOVED, diffKeys, parseKeys } from './util/diff';
 
-const MOTION_PROP_NAMES = Object.keys(OriginCSSMotion.propTypes);
+const MOTION_PROP_NAMES = Object.keys(MotionPropTypes);
 
 export function genCSSMotionList(transitionSupport, CSSMotion = OriginCSSMotion) {
   class CSSMotionList extends React.Component {

--- a/tests/CSSMotion.spec.js
+++ b/tests/CSSMotion.spec.js
@@ -255,7 +255,7 @@ describe('motion', () => {
     });
   });
 
-  it('no transition', (done) => {
+  it.only('no transition', (done) => {
     const NoCSSTransition = genCSSMotion(false);
 
     ReactDOM.render(

--- a/tests/CSSMotion.spec.js
+++ b/tests/CSSMotion.spec.js
@@ -6,11 +6,13 @@ import TestUtils from 'react-dom/test-utils';
 import expect from 'expect.js';
 import $ from 'jquery';
 import raf from 'raf';
-import CSSMotion, { genCSSMotion } from '../src/CSSMotion';
+import { genCSSMotion } from '../src/CSSMotion';
 
 import './CSSMotion.spec.css';
 
 describe('motion', () => {
+  const CSSMotion = genCSSMotion({ transitionSupport: true, forwardRef: false });
+
   let div;
   beforeEach(() => {
     div = document.createElement('div');
@@ -82,7 +84,7 @@ describe('motion', () => {
         }
       }
 
-      it(name, (done) => {
+      it(name, done => {
         ReactDOM.render(<Demo />, div, function init() {
           const nextVisible = visible[1];
           const instance = this;
@@ -90,7 +92,10 @@ describe('motion', () => {
           const doStartTest = () => {
             const $ele = $(div).find('.motion-box');
 
-            const basicClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+            const basicClassName = TestUtils.findRenderedDOMComponentWithClass(
+              instance,
+              'motion-box',
+            ).className;
             expect(basicClassName).to.contain('transition');
             expect(basicClassName).to.contain(`transition-${name}`);
             expect(basicClassName).to.not.contain(`transition-${name}-active`);
@@ -101,7 +106,10 @@ describe('motion', () => {
               expect(Number($ele.css('opacity'))).to.be(oriOpacity);
 
               setTimeout(() => {
-                const activeClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+                const activeClassName = TestUtils.findRenderedDOMComponentWithClass(
+                  instance,
+                  'motion-box',
+                ).className;
                 expect(activeClassName).to.contain('transition');
                 expect(activeClassName).to.contain(`transition-${name}`);
                 expect(activeClassName).to.contain(`transition-${name}-active`);
@@ -109,10 +117,13 @@ describe('motion', () => {
                 setTimeout(() => {
                   if (nextVisible === false) {
                     expect(
-                      TestUtils.scryRenderedDOMComponentsWithClass(instance, 'motion-box').length
+                      TestUtils.scryRenderedDOMComponentsWithClass(instance, 'motion-box').length,
                     ).to.be(0);
                   } else {
-                    const endClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+                    const endClassName = TestUtils.findRenderedDOMComponentWithClass(
+                      instance,
+                      'motion-box',
+                    ).className;
                     expect(endClassName).to.not.contain('transition');
                     expect(endClassName).to.not.contain(`transition-${name}`);
                     expect(endClassName).to.not.contain(`transition-${name}-active`);
@@ -184,19 +195,25 @@ describe('motion', () => {
         }
       }
 
-      it(name, (done) => {
+      it(name, done => {
         ReactDOM.render(<Demo />, div, function init() {
           const nextVisible = visible[1];
           const instance = this;
 
           const doStartTest = () => {
-            const basicClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+            const basicClassName = TestUtils.findRenderedDOMComponentWithClass(
+              instance,
+              'motion-box',
+            ).className;
             expect(basicClassName).to.contain('animation');
             expect(basicClassName).to.contain(`animation-${name}`);
             expect(basicClassName).to.not.contain(`animation-${name}-active`);
 
             setTimeout(() => {
-              const activeClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+              const activeClassName = TestUtils.findRenderedDOMComponentWithClass(
+                instance,
+                'motion-box',
+              ).className;
               expect(activeClassName).to.contain('animation');
               expect(activeClassName).to.contain(`animation-${name}`);
               expect(activeClassName).to.contain(`animation-${name}-active`);
@@ -222,13 +239,9 @@ describe('motion', () => {
   });
 
   describe('immediately', () => {
-    it('motionLeaveImmediately', (done) => {
+    it('motionLeaveImmediately', done => {
       ReactDOM.render(
-        <CSSMotion
-          motionName="transition"
-          motionLeaveImmediately
-          visible={false}
-        >
+        <CSSMotion motionName="transition" motionLeaveImmediately visible={false}>
           {({ style, className }) => (
             <div style={style} className={classNames('motion-box', className)} />
           )}
@@ -237,13 +250,17 @@ describe('motion', () => {
         function init() {
           const instance = this;
 
-          const basicClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+          const basicClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box')
+            .className;
           expect(basicClassName).to.contain('transition');
           expect(basicClassName).to.contain('transition-leave');
           expect(basicClassName).to.not.contain('transition-leave-active');
 
           setTimeout(() => {
-            const activeClassName = TestUtils.findRenderedDOMComponentWithClass(instance, 'motion-box').className;
+            const activeClassName = TestUtils.findRenderedDOMComponentWithClass(
+              instance,
+              'motion-box',
+            ).className;
             expect(activeClassName).to.contain('transition');
             expect(activeClassName).to.contain('transition-leave');
             expect(activeClassName).to.contain('transition-leave-active');
@@ -255,24 +272,29 @@ describe('motion', () => {
     });
   });
 
-  it.only('no transition', (done) => {
-    const NoCSSTransition = genCSSMotion(false);
+  it('no transition', done => {
+    const NoCSSTransition = genCSSMotion({ transitionSupport: false, forwardRef: false });
 
     ReactDOM.render(
-      <NoCSSTransition
-        motionName="transition"
-      >
+      <NoCSSTransition motionName="transition">
         {({ style, className }) => (
           <div style={style} className={classNames('motion-box', className)} />
         )}
-      </NoCSSTransition>
-      , div, function init() {
-        const basicClassName = TestUtils.findRenderedDOMComponentWithClass(this, 'motion-box').className;
+      </NoCSSTransition>,
+      div,
+      function init() {
+        const basicClassName = TestUtils.findRenderedDOMComponentWithClass(this, 'motion-box')
+          .className;
         expect(basicClassName).to.not.contain('transition');
         expect(basicClassName).to.not.contain('transition-appear');
         expect(basicClassName).to.not.contain('transition-appear-active');
 
         done();
-      });
+      },
+    );
+  });
+
+  it('forwardRef', () => {
+    
   });
 });

--- a/tests/CSSMotion.spec.js
+++ b/tests/CSSMotion.spec.js
@@ -6,7 +6,7 @@ import TestUtils from 'react-dom/test-utils';
 import expect from 'expect.js';
 import $ from 'jquery';
 import raf from 'raf';
-import { genCSSMotion } from '../src/CSSMotion';
+import RefCSSMotion, { genCSSMotion } from '../src/CSSMotion';
 
 import './CSSMotion.spec.css';
 
@@ -294,7 +294,25 @@ describe('motion', () => {
     );
   });
 
-  it('forwardRef', () => {
-    
+  it('forwardRef', (done) => {
+    let domNode;
+    const setRef = (node) => {
+      domNode = node;
+    };
+
+    ReactDOM.render(
+      <RefCSSMotion motionName="transition" ref={setRef}>
+        {({ style, className }, ref) => (
+          <div ref={ref} style={style} className={classNames('motion-box', className)} />
+        )}
+      </RefCSSMotion>,
+      div,
+      () => {
+        // eslint-disable-next-line no-undef
+        expect(domNode instanceof HTMLElement).to.be.ok();
+
+        done();
+      },
+    );
   });
 });

--- a/tests/CSSMotionList.spec.js
+++ b/tests/CSSMotionList.spec.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import TestUtils from 'react-dom/test-utils';
 import expect from 'expect.js';
 import { genCSSMotionList } from '../src/CSSMotionList';
-import CSSMotion from '../src/CSSMotion';
+import { genCSSMotion } from '../src/CSSMotion';
 
 import './CSSMotion.spec.css';
 
@@ -78,7 +78,8 @@ describe('motion list', () => {
     }
 
     it('with motion support', (done) => {
-      const CSSMotionList = genCSSMotionList(true);
+      const CSSMotion = genCSSMotion({ transitionSupport: true, forwardRef: false });
+      const CSSMotionList = genCSSMotionList(true, CSSMotion);
       testMotion(CSSMotionList, done, (instance) => {
         const motionList = TestUtils.scryRenderedComponentsWithType(instance, CSSMotion);
         motionList.slice(0, 2).forEach((cssMotion) => {

--- a/tests/multiple.spec.js
+++ b/tests/multiple.spec.js
@@ -12,6 +12,7 @@ class Todo extends React.Component {
   static propTypes = {
     end: PropTypes.func,
     onClick: PropTypes.func,
+    children: PropTypes.node,
   }
 
   static defaultProps = {


### PR DESCRIPTION
添加 `ref` 代理以支持内部&外部同时获得 dom 节点：

* 使用 `forwardRef` （如果支持的话）将 ref 传递给 CSSMotion 处理
* CSSMotion 本身创建另一个 `ref` 给 render props 作为代理

```jsx
const motionRef = React.createRef();

<CSSMotion
  ref={motionRef}
>
  {({ style, className }, ref) => (
    // 由于是 renderProps，需要用户自行把 ref 传递下去
    <div ref={ref} className={className} style={style} />
  )}
</CSSMotion>
```