### PR TITLE
rename componentWillReceiveProps lifecycle hook

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -94,7 +94,7 @@ export default class Animate extends React.Component {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.nextProps = nextProps;
     const nextChildren = toArrayChildren(getChildrenFromProps(nextProps));
     const props = this.props;

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -94,6 +94,7 @@ export default class Animate extends React.Component {
     });
   }
 
+  /*eslint camelcase: ["error", {allow: ["UNSAFE_componentWillReceiveProps"]}]*/
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.nextProps = nextProps;
     const nextChildren = toArrayChildren(getChildrenFromProps(nextProps));

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -94,7 +94,7 @@ export default class Animate extends React.Component {
     });
   }
 
-  /*eslint camelcase: ["error", {allow: ["UNSAFE_componentWillReceiveProps"]}]*/
+  /* eslint-disable-next-line */
   UNSAFE_componentWillReceiveProps(nextProps) {
     this.nextProps = nextProps;
     const nextChildren = toArrayChildren(getChildrenFromProps(nextProps));


### PR DESCRIPTION
componentWillReceiveProps has been renamed, and is not recommended for use.  See [here](https://fb.me/react-async-component-lifecycle-hooks) for details. In React 17.x, only the UNSAFE_ name will work.