### PR TITLE
fix: Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     "prepublish": "rc-tools run guard",
     "now-build": "npm run build"
   },
+  "peerDependencies": {
+    "react": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0"
+  },
   "devDependencies": {
     "core-js": "^2.5.1",
     "expect.js": "0.3.x",


### PR DESCRIPTION
`rc-util` has a `peerDependency`:

```
  "peerDependencies": {
    "react": "^15.0.0 || ^16.0.0",
    "react-dom": "^15.0.0 || ^16.0.0"
  },
```

This package depends on `rc-util` so it must either have `react` and `react-dom` in `dependencies` or in `peerDependencies`.

Currently this prevents using Ant Design with [Yarn Berry](https://next.yarnpkg.com/).

![image](https://user-images.githubusercontent.com/1537615/70464136-4abf0e00-1a8c-11ea-9120-c372602c8412.png)


If this is accepted I will make this change to other `rc-*` repos.

![image](https://user-images.githubusercontent.com/1537615/70464091-37ac3e00-1a8c-11ea-9768-13235aae6901.png)
