### PR TITLE
feat: support deadline

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "endOfLine": "lf",
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/examples/CSSMotionDeadline.js
+++ b/examples/CSSMotionDeadline.js
@@ -1,0 +1,73 @@
+/* eslint no-console:0, react/no-multi-comp:0 */
+
+import React from 'react';
+// import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import { CSSMotion } from 'rc-animate';
+import classNames from 'classnames';
+import './CSSMotion.less';
+
+class Demo extends React.Component {
+  state = {
+    show: true,
+  };
+
+  onTrigger = () => {
+    this.setState({
+      show: !this.state.show,
+    });
+  };
+
+  onStart = (ele, event) => {
+    console.log('start!', ele, event);
+  };
+
+  onEnd = (ele, event) => {
+    console.log('end!', ele, event);
+  };
+
+  render() {
+    const { show } = this.state;
+
+    return (
+      <div>
+        <label>
+          <input type="checkbox" onChange={this.onTrigger} checked={show} />{' '}
+          Show Component
+        </label>
+
+        <div className="grid">
+          <div>
+            <h2>With Transition Class</h2>
+            <CSSMotion
+              visible={show}
+              motionName="no-trigger"
+              motionDeadline={1000}
+              removeOnLeave
+              onAppearStart={this.onStart}
+              onEnterStart={this.onStart}
+              onLeaveStart={this.onStart}
+              onAppearEnd={this.onEnd}
+              onEnterEnd={this.onEnd}
+              onLeaveEnd={this.onEnd}
+            >
+              {({ style, className }, ref) => (
+                <div
+                  ref={ref}
+                  className={classNames('demo-block', className)}
+                  style={style}
+                />
+              )}
+            </CSSMotion>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<Demo />, document.getElementById('__react-content'));
+
+// Remove for IE9 test
+// const aaa = document.getElementsByClassName('navbar')[0];
+// aaa.parentNode.removeChild(aaa);


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/23569

`rc-animate` 不能升级 father 有点蛋疼，花了好久来复原 node 10 的环境才跑起来。antd 里的问题在于看不见的元素 chrome 不会进行动画渲染，导致永远不会触发动画事件。这使得虚拟滚动动画结束不了，添加一个 deadline 属性用于强制最后的 flush 操作。

PS: now 似乎挂了很久了