### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
     "@ant-design/css-animation": "^1.7.2",
     "raf": "^3.4.0",
     "rc-util": "^4.15.3"
+  },
+  "peerDependencies": {
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "pre-commit": "1.x",
     "rc-test": "6.x",
     "rc-tools": "8.x",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "velocity-animate": "~1.2.2"
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
     "pre-commit": "1.x",
     "rc-test": "6.x",
     "rc-tools": "8.x",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "velocity-animate": "~1.2.2"
   },
   "pre-commit": [


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
